### PR TITLE
Fixed #13: build-helper-maven-plugin is missing version

### DIFF
--- a/android-jain-sip-ext/pom.xml
+++ b/android-jain-sip-ext/pom.xml
@@ -173,6 +173,7 @@
 			 <plugin>
 				<groupId>org.codehaus.mojo</groupId>
 			    <artifactId>build-helper-maven-plugin</artifactId>
+			    <version>3.0.0</version>
 			    <executions>
 			        <execution>
 			            <id>add-source</id>


### PR DESCRIPTION
@jaimecasero can you have a look; it's pretty trivial